### PR TITLE
Fixes to the export and wait logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v0.3.0
+### Changed
+- Changed the way timeouts and retries work.
+    - It will now time out after the specified timeout without retries.
+    - If it does time out it will check to see if it succeeded before reporting failure.
+
 ## v0.2.0 (2020-04-28)
 ### Added
 - Added `GCLOUD_VERBOSITY` environment option

--- a/scripts/gcloud-sql-export.sh
+++ b/scripts/gcloud-sql-export.sh
@@ -51,9 +51,16 @@ function gcloud_activate_service_account() {
 function gcloud_sql_export() {
   local backup_timestamp="$1"
   gcs_backup_path="gs://${GOOGLE_SQL_BACKUP_BUCKET}/${GOOGLE_SQL_BACKUP_BUCKET_PATH}/${backup_timestamp}_${GOOGLE_SQL_INSTANCE_NAME}_${DATABASE}.gz"
-  gcloud --verbosity="${GCLOUD_VERBOSITY}" sql export sql "${GOOGLE_SQL_INSTANCE_NAME}" --database "${DATABASE}" "${gcs_backup_path}" \
-    || ( echo "Export taking longer than expected - waiting another ${GCLOUD_WAIT_TIMEOUT} seconds." ; \
-      gcloud --verbosity="${GCLOUD_VERBOSITY}" sql operations wait --timeout "${GCLOUD_WAIT_TIMEOUT}" --quiet $(gcloud sql operations list --instance="${GOOGLE_SQL_INSTANCE_NAME}" --filter='status=RUNNING' --format="value(NAME)") )
+  gcloud --verbosity="${GCLOUD_VERBOSITY}" sql export sql "${GOOGLE_SQL_INSTANCE_NAME}" --database "${DATABASE}" "${gcs_backup_path}" --async
+  echo "Export started, waiting ${GCLOUD_WAIT_TIMEOUT} seconds for it to complete."
+  if ! gcloud --verbosity="${GCLOUD_VERBOSITY}" sql operations wait --timeout "${GCLOUD_WAIT_TIMEOUT}" --quiet "$(gcloud sql operations list --instance="${GOOGLE_SQL_INSTANCE_NAME}" --filter='status=RUNNING' --format="value(NAME)")"; then
+    echo "Wait timed out after ${GCLOUD_WAIT_TIMEOUT} seconds, checking to see if it has succeeded."
+    if [ -z "$(gcloud sql operations list --instance="${GOOGLE_SQL_INSTANCE_NAME}" --filter='status=DONE AND START>=-P1H AND TYPE=EXPORT' --format='value(NAME)')" ]; then
+      echo "Backup failed to complete, or failed to complete within the alotted timeout."
+      return 1
+    fi
+  fi
+  echo "Backup complete."
 }
 
 # Return a GCS filepath, determined by the supplied `backup_timestamp` prefix.

--- a/scripts/gcloud-sql-export.sh
+++ b/scripts/gcloud-sql-export.sh
@@ -55,6 +55,7 @@ function gcloud_sql_export() {
   echo "Export started, waiting ${GCLOUD_WAIT_TIMEOUT} seconds for it to complete."
   if ! gcloud --verbosity="${GCLOUD_VERBOSITY}" sql operations wait --timeout "${GCLOUD_WAIT_TIMEOUT}" --quiet "$selfLink"; then
     echo "Wait timed out after ${GCLOUD_WAIT_TIMEOUT} seconds, checking to see if it has succeeded."
+    sleep 10
     if [ -z "$(gcloud sql operations list --instance="${GOOGLE_SQL_INSTANCE_NAME}" --filter="status=DONE selfLink=$selfLink" --format='value(NAME)')" ]; then
       echo "Backup failed to complete, or failed to complete within the alotted timeout."
       return 1

--- a/scripts/gcloud-sql-export.sh
+++ b/scripts/gcloud-sql-export.sh
@@ -51,11 +51,11 @@ function gcloud_activate_service_account() {
 function gcloud_sql_export() {
   local backup_timestamp="$1"
   gcs_backup_path="gs://${GOOGLE_SQL_BACKUP_BUCKET}/${GOOGLE_SQL_BACKUP_BUCKET_PATH}/${backup_timestamp}_${GOOGLE_SQL_INSTANCE_NAME}_${DATABASE}.gz"
-  gcloud --verbosity="${GCLOUD_VERBOSITY}" sql export sql "${GOOGLE_SQL_INSTANCE_NAME}" --database "${DATABASE}" "${gcs_backup_path}" --async
+  selfLink=$(gcloud --verbosity="${GCLOUD_VERBOSITY}" sql export sql "${GOOGLE_SQL_INSTANCE_NAME}" --database "${DATABASE}" "${gcs_backup_path}" --async)
   echo "Export started, waiting ${GCLOUD_WAIT_TIMEOUT} seconds for it to complete."
   if ! gcloud --verbosity="${GCLOUD_VERBOSITY}" sql operations wait --timeout "${GCLOUD_WAIT_TIMEOUT}" --quiet "$(gcloud sql operations list --instance="${GOOGLE_SQL_INSTANCE_NAME}" --filter='status=RUNNING' --format="value(NAME)")"; then
     echo "Wait timed out after ${GCLOUD_WAIT_TIMEOUT} seconds, checking to see if it has succeeded."
-    if [ -z "$(gcloud sql operations list --instance="${GOOGLE_SQL_INSTANCE_NAME}" --filter='status=DONE AND START>=-P1H AND TYPE=EXPORT' --format='value(NAME)')" ]; then
+    if [ -z "$(gcloud sql operations list --instance="${GOOGLE_SQL_INSTANCE_NAME}" --filter="status=DONE selfLink=$selfLink" --format='value(NAME)')" ]; then
       echo "Backup failed to complete, or failed to complete within the alotted timeout."
       return 1
     fi

--- a/scripts/gcloud-sql-export.sh
+++ b/scripts/gcloud-sql-export.sh
@@ -53,7 +53,7 @@ function gcloud_sql_export() {
   gcs_backup_path="gs://${GOOGLE_SQL_BACKUP_BUCKET}/${GOOGLE_SQL_BACKUP_BUCKET_PATH}/${backup_timestamp}_${GOOGLE_SQL_INSTANCE_NAME}_${DATABASE}.gz"
   selfLink=$(gcloud --verbosity="${GCLOUD_VERBOSITY}" sql export sql "${GOOGLE_SQL_INSTANCE_NAME}" --database "${DATABASE}" "${gcs_backup_path}" --async)
   echo "Export started, waiting ${GCLOUD_WAIT_TIMEOUT} seconds for it to complete."
-  if ! gcloud --verbosity="${GCLOUD_VERBOSITY}" sql operations wait --timeout "${GCLOUD_WAIT_TIMEOUT}" --quiet "$(gcloud sql operations list --instance="${GOOGLE_SQL_INSTANCE_NAME}" --filter='status=RUNNING' --format="value(NAME)")"; then
+  if ! gcloud --verbosity="${GCLOUD_VERBOSITY}" sql operations wait --timeout "${GCLOUD_WAIT_TIMEOUT}" --quiet "$selfLink"; then
     echo "Wait timed out after ${GCLOUD_WAIT_TIMEOUT} seconds, checking to see if it has succeeded."
     if [ -z "$(gcloud sql operations list --instance="${GOOGLE_SQL_INSTANCE_NAME}" --filter="status=DONE selfLink=$selfLink" --format='value(NAME)')" ]; then
       echo "Backup failed to complete, or failed to complete within the alotted timeout."


### PR DESCRIPTION
We now kick off the export asyncronously and then immediately wait for the specific timeout. I think this make more sense than relying on the default timeout and retrying with the user specified timeout multipe times. 

If that fails then we check to see if a export has successfully been completed in the last hour, if so assume it was out one and report success, otherwise return failue.

We'll need to specify the timeout in the Kustomize now as the default 600s wont be enough for prod portal.  